### PR TITLE
Use web.stream prefix (rather than web.api) for controller methods th…

### DIFF
--- a/src/main/java/io/avaje/metrics/agent/AddTimerMetricMethodAdapter.java
+++ b/src/main/java/io/avaje/metrics/agent/AddTimerMetricMethodAdapter.java
@@ -111,7 +111,15 @@ public class AddTimerMetricMethodAdapter extends AdviceAdapter {
     if (explicitFullName) {
       return name;
     }
-    return classAdapter.getMetricPrefix() + "." + name;
+    return classAdapter.metricPrefix(methodReturnsStream()) + "." + name;
+  }
+
+  /**
+   * Return true if this method returns java.util.stream.Stream.
+   */
+  private boolean methodReturnsStream() {
+    String returnType = methodDesc.substring(methodDesc.indexOf(')') + 1);
+    return returnType.startsWith("Ljava/util/stream/Stream;");
   }
 
   public void visitCode() {

--- a/src/main/java/io/avaje/metrics/agent/ClassAdapterMetric.java
+++ b/src/main/java/io/avaje/metrics/agent/ClassAdapterMetric.java
@@ -121,7 +121,7 @@ public class ClassAdapterMetric extends ClassVisitor implements Opcodes {
   /**
    * Return the class level metric prefix used to prefix timed metrics on methods.
    */
-  String getMetricPrefix() {
+  String metricPrefix(boolean streamReturn) {
     if (name != null) {
       // explicit name via @Timed
       return name;
@@ -131,7 +131,7 @@ public class ClassAdapterMetric extends ClassVisitor implements Opcodes {
       return prefix + "." + shortName;
     }
     if (detectWebController) {
-      return deriveControllerName();
+      return deriveControllerName(streamReturn);
     }
     if (detectWebService) {
       return deriveWebServiceName();
@@ -139,8 +139,8 @@ public class ClassAdapterMetric extends ClassVisitor implements Opcodes {
     return enhanceContext.isNameIncludesPackage() ? longName : "app." + shortName;
   }
 
-  private String deriveControllerName() {
-    return "web.api." + shortName;
+  private String deriveControllerName(boolean streamReturn) {
+    return streamReturn ? "web.stream." + shortName : "web.api." + shortName;
   }
 
   private String deriveWebServiceName() {

--- a/src/test/java/org/test/web/api/StreamResource.java
+++ b/src/test/java/org/test/web/api/StreamResource.java
@@ -1,0 +1,28 @@
+package org.test.web.api;
+
+import io.avaje.http.api.Controller;
+import io.avaje.http.api.Get;
+
+import java.util.stream.Stream;
+
+@Controller
+public class StreamResource {
+
+  @Get
+  public Stream<String> streamAll() {
+    return Stream.of("a", "b", "c");
+  }
+
+  @Get
+  public String findOne() {
+    return "one";
+  }
+
+  public Stream<String> publicStreamMethod() {
+    return Stream.of("x", "y");
+  }
+
+  public String publicNormalMethod() {
+    return "normal";
+  }
+}

--- a/src/test/java/org/test/web/api/StreamResourceTest.java
+++ b/src/test/java/org/test/web/api/StreamResourceTest.java
@@ -1,0 +1,53 @@
+package org.test.web.api;
+
+import io.avaje.metrics.Metrics;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StreamResourceTest extends BaseTest {
+
+  @Test
+  public void testStreamMethodUsesStreamPrefix() {
+
+    StreamResource resource = new StreamResource();
+
+    Metrics.testReset();
+
+    resource.streamAll();
+    assertEquals("web.stream.StreamResource.streamAll", Metrics.testLastMetricName());
+  }
+
+  @Test
+  public void testNonStreamMethodUsesApiPrefix() {
+
+    StreamResource resource = new StreamResource();
+
+    Metrics.testReset();
+
+    resource.findOne();
+    assertEquals("web.api.StreamResource.findOne", Metrics.testLastMetricName());
+  }
+
+  @Test
+  public void testPublicStreamMethodUsesStreamPrefix() {
+
+    StreamResource resource = new StreamResource();
+
+    Metrics.testReset();
+
+    resource.publicStreamMethod();
+    assertEquals("web.stream.StreamResource.publicStreamMethod", Metrics.testLastMetricName());
+  }
+
+  @Test
+  public void testPublicNonStreamMethodUsesApiPrefix() {
+
+    StreamResource resource = new StreamResource();
+
+    Metrics.testReset();
+
+    resource.publicNormalMethod();
+    assertEquals("web.api.StreamResource.publicNormalMethod", Metrics.testLastMetricName());
+  }
+}


### PR DESCRIPTION
…an having streaming results

The reason for this change, is that generally the streaming endpoints have quite different response times (longer response times) and we want to view those separately from the non-streaming endpoints. Using the different prefix allows us to easily separate those two groups of metrics.