### PR TITLE
Remove the old request timing unused code

### DIFF
--- a/src/main/java/io/avaje/metrics/agent/AddTimerMetricMethodAdapter.java
+++ b/src/main/java/io/avaje/metrics/agent/AddTimerMetricMethodAdapter.java
@@ -11,7 +11,6 @@ import io.avaje.metrics.agent.asm.commons.AdviceAdapter;
 import java.util.Arrays;
 
 import static io.avaje.metrics.agent.Transformer.ASM_VERSION;
-import static io.avaje.metrics.agent.asm.Type.BOOLEAN_TYPE;
 import static io.avaje.metrics.agent.asm.Type.LONG_TYPE;
 import static io.avaje.metrics.agent.asm.Type.getObjectType;
 
@@ -39,8 +38,6 @@ public class AddTimerMetricMethodAdapter extends AdviceAdapter {
   private static final String OPERATION_EVENT_END_ERROR = "endWithError";
   private static final String OPERATION_EVENT_END_ERROR_DESC = "(Ljava/lang/Throwable;)V";
 
-  private static final String METHOD_IS_ACTIVE_THREAD_CONTEXT = "isRequestTiming";
-
   private final ClassAdapterMetric classAdapter;
 
   private final EnhanceContext context;
@@ -57,8 +54,6 @@ public class AddTimerMetricMethodAdapter extends AdviceAdapter {
   private boolean explicitFullName;
 
   private int[] buckets;
-
-  private int posUseContext;
 
   private int posTimeStart;
   private int posEvent;
@@ -273,12 +268,7 @@ public class AddTimerMetricMethodAdapter extends AdviceAdapter {
         mv.visitFieldInsn(GETSTATIC, className, "_$metric_" + metricIndex, LTIMED_METRIC);
         loadLocal(posTimeStart);
         String methodDesc = isError ? OPERATION_ERR : OPERATION_END;
-        if (context.isIncludeRequestTiming()) {
-          loadLocal(posUseContext);
-          mv.visitMethodInsn(INVOKEINTERFACE, TIMED_METRIC, methodDesc, "(JZ)V", true);
-        } else {
-          mv.visitMethodInsn(INVOKEINTERFACE, TIMED_METRIC, methodDesc, "(J)V", true);
-        }
+        mv.visitMethodInsn(INVOKEINTERFACE, TIMED_METRIC, methodDesc, "(J)V", true);
       }
     }
   }
@@ -299,12 +289,6 @@ public class AddTimerMetricMethodAdapter extends AdviceAdapter {
         mv.visitMethodInsn(INVOKEINTERFACE, TIMED_METRIC, OPERATION_START_EVENT, "()" + LTIMED_EVENT, true);
         storeLocal(posEvent);
       } else {
-        if (context.isIncludeRequestTiming()) {
-          posUseContext = newLocal(BOOLEAN_TYPE);
-          mv.visitFieldInsn(GETSTATIC, className, "_$metric_" + metricIndex, LTIMED_METRIC);
-          mv.visitMethodInsn(INVOKEINTERFACE, TIMED_METRIC, METHOD_IS_ACTIVE_THREAD_CONTEXT, "()Z", true);
-          mv.visitVarInsn(ISTORE, posUseContext);
-        }
         posTimeStart = newLocal(LONG_TYPE);
         mv.visitMethodInsn(INVOKESTATIC, "java/lang/System", "nanoTime", "()J", false);
         mv.visitVarInsn(LSTORE, posTimeStart);

--- a/src/main/java/io/avaje/metrics/agent/AgentManifest.java
+++ b/src/main/java/io/avaje/metrics/agent/AgentManifest.java
@@ -35,7 +35,6 @@ public class AgentManifest {
 
   private final Set<String> includePackages = new HashSet<>();
 
-  private boolean includeRequestTiming;
   private boolean includeSpringComponents;
   private boolean includeJaxRsComponents;
   private boolean includeJEEComponents;
@@ -89,10 +88,6 @@ public class AgentManifest {
     return includeSpringComponents;
   }
 
-  public boolean isIncludeRequestTiming() {
-    return includeRequestTiming;
-  }
-
   /**
    * Read all the specific manifest files and return the set of packages containing type query beans.
    */
@@ -130,7 +125,6 @@ public class AgentManifest {
       debugLevel = Integer.parseInt(debug);
     }
 
-    includeRequestTiming = bool(attributes, "requestTiming");
     timedSpansMode = TimedSpansMode.of(attributes.getValue("timedSpans"));
     includeStaticMethods = bool(attributes, "includeStaticMethods");
     enhanceSingleton = bool(attributes, "enhanceSingleton", enhanceSingleton);

--- a/src/main/java/io/avaje/metrics/agent/EnhanceContext.java
+++ b/src/main/java/io/avaje/metrics/agent/EnhanceContext.java
@@ -131,12 +131,8 @@ class EnhanceContext {
     return includeStaticMethods;
   }
 
-  boolean isIncludeRequestTiming() {
-    return manifest.isIncludeRequestTiming();
-  }
-
   boolean isTimedSpansEnabled(TimedSpanMode classMode, TimedSpanMode methodMode) {
-    return !manifest.isIncludeRequestTiming() && manifest.isTimedSpansEnabled(classMode, methodMode);
+    return manifest.isTimedSpansEnabled(classMode, methodMode);
   }
 
   boolean isNameIncludesPackage() {

--- a/src/test/java/io/avaje/metrics/Metrics.java
+++ b/src/test/java/io/avaje/metrics/Metrics.java
@@ -15,8 +15,6 @@ public class Metrics {
   private static String lastMetricName;
 
   private static int lastMetricOpcode;
-
-  private static boolean lastActiveThreadContext;
   private static String lastOperationKind;
   private static Throwable lastThrowable;
 
@@ -86,18 +84,17 @@ public class Metrics {
   /**
    * Called when a timer ends so that we can assert the call occured.
    */
-  protected static void testOperationEnd(String name, boolean success, boolean activeThreadContext) {
-    testOperationEnd(name, success, activeThreadContext, "add");
+  protected static void testOperationEnd(String name, boolean success) {
+    testOperationEnd(name, success, "add");
   }
 
-  protected static void testOperationEnd(String name, boolean success, boolean activeThreadContext, String operationKind) {
-    testOperationEnd(name, success, activeThreadContext, operationKind, null);
+  protected static void testOperationEnd(String name, boolean success, String operationKind) {
+    testOperationEnd(name, success, operationKind, null);
   }
 
-  protected static void testOperationEnd(String name, boolean success, boolean activeThreadContext, String operationKind, Throwable throwable) {
+  protected static void testOperationEnd(String name, boolean success, String operationKind, Throwable throwable) {
     lastMetricName  = name;
     lastMetricOpcode = success ? 1 : 191;
-    lastActiveThreadContext = activeThreadContext;
     lastOperationKind = operationKind;
     lastThrowable = throwable;
   }
@@ -110,10 +107,6 @@ public class Metrics {
     return 191 == lastMetricOpcode;
   }
 
-  public static boolean testLastActiveThreadContext() {
-    return lastActiveThreadContext;
-  }
-
   public static int testLastMetricOpcode() {
     return lastMetricOpcode;
   }
@@ -121,7 +114,6 @@ public class Metrics {
   public static void testReset() {
     lastMetricName = null;
     lastMetricOpcode = 0;
-    lastActiveThreadContext = false;
     lastOperationKind = null;
     lastThrowable = null;
   }

--- a/src/test/java/io/avaje/metrics/MockBucketTimer.java
+++ b/src/test/java/io/avaje/metrics/MockBucketTimer.java
@@ -17,34 +17,19 @@ public class MockBucketTimer implements Timer {
 
   @Override
   public void add(long startNanos) {
-    testOperationEnd(true, startNanos, false);
-  }
-
-  @Override
-  public void add(long startNanos, boolean activeThreadContext) {
-    testOperationEnd(true, startNanos, activeThreadContext);
+    testOperationEnd(true, startNanos);
   }
 
   @Override
   public void addErr(long startNanos) {
-    testOperationEnd(false, startNanos, false);
+    testOperationEnd(false, startNanos);
   }
 
-  @Override
-  public void addErr(long startNanos, boolean activeThreadContext) {
-    testOperationEnd(false, startNanos, activeThreadContext);
-  }
-
-  private void testOperationEnd(boolean success, long startNanos, boolean activeThreadContext) {
+  private void testOperationEnd(boolean success, long startNanos) {
     long exeNanos = System.nanoTime() - startNanos;
-    System.out.println("... " + name + " operationEnd exe:" + exeNanos + " success:" + success + " activeThreadContext:" + activeThreadContext);
+    System.out.println("... " + name + " operationEnd exe:" + exeNanos + " success:" + success);
     count++;
-    Metrics.testOperationEnd(name, success, activeThreadContext, success ? "add" : "addErr");
-  }
-
-  @Override
-  public boolean isRequestTiming() {
-    return true;
+    Metrics.testOperationEnd(name, success, success ? "add" : "addErr");
   }
 
   @Override
@@ -82,19 +67,19 @@ public class MockBucketTimer implements Timer {
     @Override
     public void end() {
       count++;
-      Metrics.testOperationEnd(name, true, false, "event.end");
+      Metrics.testOperationEnd(name, true, "event.end");
     }
 
     @Override
     public void endWithError() {
       count++;
-      Metrics.testOperationEnd(name, false, false, "event.endWithError");
+      Metrics.testOperationEnd(name, false, "event.endWithError");
     }
 
     @Override
     public void endWithError(Throwable error) {
       count++;
-      Metrics.testOperationEnd(name, false, false, "event.endWithError", error);
+      Metrics.testOperationEnd(name, false, "event.endWithError", error);
     }
   }
 }

--- a/src/test/java/io/avaje/metrics/MockTimer.java
+++ b/src/test/java/io/avaje/metrics/MockTimer.java
@@ -17,34 +17,19 @@ public class MockTimer implements Timer {
 
   @Override
   public void add(long startNanos) {
-    testOperationEnd(true, startNanos, false);
-  }
-
-  @Override
-  public void add(long startNanos, boolean activeThreadContext) {
-    testOperationEnd(true, startNanos, activeThreadContext);
+    testOperationEnd(true, startNanos);
   }
 
   @Override
   public void addErr(long startNanos) {
-    testOperationEnd(false, startNanos, false);
+    testOperationEnd(false, startNanos);
   }
 
-  @Override
-  public void addErr(long startNanos, boolean activeThreadContext) {
-    testOperationEnd(false, startNanos, activeThreadContext);
-  }
-
-  private void testOperationEnd(boolean success, long startNanos, boolean activeThreadContext) {
+  private void testOperationEnd(boolean success, long startNanos) {
     long exeNanos = System.nanoTime() - startNanos;
-    System.out.println("... " + name + " testOperationEnd exe:" + exeNanos + " success:" + success + " activeThreadContext:" + activeThreadContext);
+    System.out.println("... " + name + " testOperationEnd exe:" + exeNanos + " success:" + success);
     count++;
-    Metrics.testOperationEnd(name, success, activeThreadContext, success ? "add" : "addErr");
-  }
-
-  @Override
-  public boolean isRequestTiming() {
-    return true;
+    Metrics.testOperationEnd(name, success, success ? "add" : "addErr");
   }
 
   @Override
@@ -82,19 +67,19 @@ public class MockTimer implements Timer {
     @Override
     public void end() {
       count++;
-      Metrics.testOperationEnd(name, true, false, "event.end");
+      Metrics.testOperationEnd(name, true, "event.end");
     }
 
     @Override
     public void endWithError() {
       count++;
-      Metrics.testOperationEnd(name, false, false, "event.endWithError");
+      Metrics.testOperationEnd(name, false, "event.endWithError");
     }
 
     @Override
     public void endWithError(Throwable error) {
       count++;
-      Metrics.testOperationEnd(name, false, false, "event.endWithError", error);
+      Metrics.testOperationEnd(name, false, "event.endWithError", error);
     }
   }
 }

--- a/src/test/java/io/avaje/metrics/Timer.java
+++ b/src/test/java/io/avaje/metrics/Timer.java
@@ -6,12 +6,8 @@ package io.avaje.metrics;
 public interface Timer {
 
   void add(long startNanos);
-  void add(long startNanos, boolean activeThreadContext);
   void addErr(long startNanos);
-  void addErr(long startNanos, boolean activeThreadContext);
   Event startEvent();
-
-  boolean isRequestTiming();
 
   interface Event {
     void end();


### PR DESCRIPTION
This feature was desupported from avaje-metrics but this remained, so this is a cleanup removing this old now unused code.