### PR TITLE
Add "Label-Tag" metric naming option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,21 @@ The agent also supports a `timedSpans` manifest setting with values:
 `default-off`, `default-on`, and `disabled`.
 If unset, timed spans default to off.
 `disabled` turns off timed spans globally, including explicit `@Timed(span = Timed.SpanMode.ON)` settings, while leaving plain timing metrics enabled.
+
+The agent also supports a `timedMetricNaming` manifest setting with values:
+`full-name` and `label-tag`.
+If unset, `full-name` is used.
+
+- `full-name` keeps the existing metric naming, for example:
+  `web.api.CustomerResource.staticGeneral`
+- `label-tag` changes non-bucket timed metrics to use the base metric name plus a `label:` tag, for example:
+  `Metrics.timer("web.api", "label:CustomerResource.staticGeneral")`
+
+In `label-tag` mode:
+
+- class `@Timed(prefix = "...")` becomes the base metric name
+- class `@Timed(name = "...")` remains the base metric name
+- method `@Timed(name = "...")` becomes the `label:` tag value
+- otherwise non-web timed classes default to the base metric name `app.component`
+- `nameIncludePackages=true` affects the label value rather than the base metric name
+- bucket timers continue to use full-name metric naming in this first cut

--- a/src/main/java/io/avaje/metrics/agent/AddTimerMetricMethodAdapter.java
+++ b/src/main/java/io/avaje/metrics/agent/AddTimerMetricMethodAdapter.java
@@ -37,6 +37,7 @@ public class AddTimerMetricMethodAdapter extends AdviceAdapter {
   private static final String OPERATION_EVENT_END = "end";
   private static final String OPERATION_EVENT_END_ERROR = "endWithError";
   private static final String OPERATION_EVENT_END_ERROR_DESC = "(Ljava/lang/Throwable;)V";
+  private static final String CREATE_TAGGED_TIMER_DESC = "(Ljava/lang/String;[Ljava/lang/String;)Lio/avaje/metrics/Timer;";
 
   private final ClassAdapterMetric classAdapter;
 
@@ -51,6 +52,7 @@ public class AddTimerMetricMethodAdapter extends AdviceAdapter {
   private final int metricIndex;
 
   private String name;
+  private boolean explicitName;
   private boolean explicitFullName;
 
   private int[] buckets;
@@ -90,8 +92,9 @@ public class AddTimerMetricMethodAdapter extends AdviceAdapter {
   private void setName(String metricName) {
     metricName = metricName.trim();
     if (!metricName.isEmpty()) {
+      this.explicitName = true;
       this.name = metricName;
-      this.explicitFullName = name.contains(".");
+      this.explicitFullName = metricName.contains(".");
     }
   }
 
@@ -120,6 +123,25 @@ public class AddTimerMetricMethodAdapter extends AdviceAdapter {
       return name;
     }
     return classAdapter.getMetricPrefix() + "." + name;
+  }
+
+  private String getMetricLabel() {
+    if (explicitName) {
+      return name;
+    }
+    return classAdapter.getMetricLabelPrefix() + "." + name;
+  }
+
+  private boolean useLabelTagMetricNaming() {
+    int[] bucketRanges = getBuckets();
+    return context.isTimedMetricNamingLabelTag() && (bucketRanges == null || bucketRanges.length == 0);
+  }
+
+  private String getMetricDescription() {
+    if (useLabelTagMetricNaming()) {
+      return classAdapter.getMetricBaseName() + " [label:" + getMetricLabel() + "]";
+    }
+    return getUniqueMetricName();
   }
 
   public void visitCode() {
@@ -305,19 +327,30 @@ public class AddTimerMetricMethodAdapter extends AdviceAdapter {
     } else {
       // apply any metric name mappings to the uniqueMethodName to get
       // the final metric name that will be used
-      String mappedMetricName = getUniqueMetricName();
-      context.logAddingMetric(mappedMetricName);
+      String metricDescription = getMetricDescription();
+      context.logAddingMetric(metricDescription);
       if (isLog(1)) {
-        log(1, "# Add Metric[" + mappedMetricName + "] index[" + i + "]", "");
+        log(1, "# Add Metric[" + metricDescription + "] index[" + i + "]", "");
       }
 
       Label l0 = new Label();
       mv.visitLabel(l0);
       mv.visitLineNumber(1, l0);
-      mv.visitLdcInsn(mappedMetricName);
 
       int[] buckets = getBuckets();
-      if (buckets == null || buckets.length == 0) {
+      if (useLabelTagMetricNaming()) {
+        mv.visitLdcInsn(classAdapter.getMetricBaseName());
+        push(mv, 1);
+        mv.visitTypeInsn(ANEWARRAY, "java/lang/String");
+        mv.visitInsn(DUP);
+        push(mv, 0);
+        mv.visitLdcInsn("label:" + getMetricLabel());
+        mv.visitInsn(AASTORE);
+        mv.visitMethodInsn(INVOKESTATIC, METRIC_MANAGER, isTraced() ? CREATE_TRACED_TIMER : CREATE_TIMER, CREATE_TAGGED_TIMER_DESC, false);
+        mv.visitFieldInsn(PUTSTATIC, className, "_$metric_" + i, LTIMED_METRIC);
+
+      } else if (buckets == null || buckets.length == 0) {
+        mv.visitLdcInsn(getUniqueMetricName());
         mv.visitMethodInsn(INVOKESTATIC, METRIC_MANAGER, isTraced() ? CREATE_TRACED_TIMER : CREATE_TIMER, "(Ljava/lang/String;)Lio/avaje/metrics/Timer;", false);
         mv.visitFieldInsn(PUTSTATIC, className, "_$metric_" + i, LTIMED_METRIC);
 
@@ -327,6 +360,7 @@ public class AddTimerMetricMethodAdapter extends AdviceAdapter {
           log(3, "... init with buckets", Arrays.toString(buckets));
         }
 
+        mv.visitLdcInsn(getUniqueMetricName());
         push(mv, buckets.length);
         mv.visitIntInsn(NEWARRAY, Opcodes.T_INT);
         for (int j = 0; j < buckets.length; j++) {
@@ -344,7 +378,7 @@ public class AddTimerMetricMethodAdapter extends AdviceAdapter {
   void addFieldDefinition(ClassVisitor cv, int i) {
     if (isEnhanced()) {
       if (isLog(4)) {
-        log(4, "... init field index[" + i + "] METHOD[" + getUniqueMetricName() + "]", "");
+        log(4, "... init field index[" + i + "] METHOD[" + getMetricDescription() + "]", "");
       }
       FieldVisitor fv = cv.visitField(ACC_PRIVATE + ACC_STATIC, "_$metric_" + i, LTIMED_METRIC, null, null);
       fv.visitEnd();

--- a/src/main/java/io/avaje/metrics/agent/AgentManifest.java
+++ b/src/main/java/io/avaje/metrics/agent/AgentManifest.java
@@ -39,6 +39,7 @@ public class AgentManifest {
   private boolean includeJaxRsComponents;
   private boolean includeJEEComponents;
   private TimedSpansMode timedSpansMode = TimedSpansMode.DEFAULT_OFF;
+  private TimedMetricNaming timedMetricNaming = TimedMetricNaming.FULL_NAME;
 
   private boolean nameIncludePackages;
   private int debugLevel;
@@ -126,6 +127,7 @@ public class AgentManifest {
     }
 
     timedSpansMode = TimedSpansMode.of(attributes.getValue("timedSpans"));
+    timedMetricNaming = TimedMetricNaming.of(attributes.getValue("timedMetricNaming"));
     includeStaticMethods = bool(attributes, "includeStaticMethods");
     enhanceSingleton = bool(attributes, "enhanceSingleton", enhanceSingleton);
     enhanceAvajeComponent = bool(attributes, "enhanceAvajeComponent", enhanceAvajeComponent);
@@ -192,6 +194,10 @@ public class AgentManifest {
 
   boolean isTimedSpansEnabled(TimedSpanMode classMode, TimedSpanMode methodMode) {
     return timedSpansMode.resolve(classMode, methodMode);
+  }
+
+  boolean isTimedMetricNamingLabelTag() {
+    return timedMetricNaming == TimedMetricNaming.LABEL_TAG;
   }
 
   public boolean isEnhanceSingleton() {

--- a/src/main/java/io/avaje/metrics/agent/ClassAdapterMetric.java
+++ b/src/main/java/io/avaje/metrics/agent/ClassAdapterMetric.java
@@ -144,12 +144,40 @@ public class ClassAdapterMetric extends ClassVisitor implements Opcodes {
     return enhanceContext.isNameIncludesPackage() ? longName : "app." + shortName;
   }
 
+  String getMetricBaseName() {
+    if (name != null) {
+      return name;
+    }
+    if (prefix != null) {
+      return prefix;
+    }
+    if (detectWebController) {
+      return deriveControllerBaseName();
+    }
+    if (detectWebService) {
+      return deriveWebServiceBaseName();
+    }
+    return "app.component";
+  }
+
+  String getMetricLabelPrefix() {
+    return enhanceContext.isNameIncludesPackage() ? longName : shortName;
+  }
+
   private String deriveControllerName() {
-    return "web.api." + shortName;
+    return deriveControllerBaseName() + "." + shortName;
   }
 
   private String deriveWebServiceName() {
-    return "web.ws." + shortName;
+    return deriveWebServiceBaseName() + "." + shortName;
+  }
+
+  private String deriveControllerBaseName() {
+    return "web.api";
+  }
+
+  private String deriveWebServiceBaseName() {
+    return "web.ws";
   }
 
   private void setName(String name) {

--- a/src/main/java/io/avaje/metrics/agent/EnhanceContext.java
+++ b/src/main/java/io/avaje/metrics/agent/EnhanceContext.java
@@ -135,6 +135,10 @@ class EnhanceContext {
     return manifest.isTimedSpansEnabled(classMode, methodMode);
   }
 
+  boolean isTimedMetricNamingLabelTag() {
+    return manifest.isTimedMetricNamingLabelTag();
+  }
+
   boolean isNameIncludesPackage() {
     return manifest.isNameIncludesPackage();
   }

--- a/src/main/java/io/avaje/metrics/agent/TimedMetricNaming.java
+++ b/src/main/java/io/avaje/metrics/agent/TimedMetricNaming.java
@@ -1,0 +1,19 @@
+package io.avaje.metrics.agent;
+
+enum TimedMetricNaming {
+  FULL_NAME,
+  LABEL_TAG;
+
+  static TimedMetricNaming of(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return FULL_NAME;
+    }
+    switch (value.trim()) {
+      case "label-tag":
+        return LABEL_TAG;
+      case "full-name":
+      default:
+        return FULL_NAME;
+    }
+  }
+}

--- a/src/test/java/io/avaje/metrics/Metrics.java
+++ b/src/test/java/io/avaje/metrics/Metrics.java
@@ -1,5 +1,6 @@
 package io.avaje.metrics;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -8,62 +9,89 @@ import java.util.Map;
  */
 public class Metrics {
 
-  private static Map<String, Timer> cache = new HashMap<>();
+  private static final Map<String, Timer> cache = new HashMap<>();
 
-  private static Map<String, Timer> bucketCache = new HashMap<>();
+  private static final Map<String, Timer> bucketCache = new HashMap<>();
 
   private static String lastMetricName;
+  private static String[] lastMetricTags;
 
   private static int lastMetricOpcode;
   private static String lastOperationKind;
   private static Throwable lastThrowable;
 
+  public static Timer timer(String name, String... tags) {
+    return timer(name, false, tags);
+  }
+
+  public static Timer tracedTimer(String name, String... tags) {
+    return timer(name, true, tags);
+  }
+
   /**
    * Method called by the enhancement code.
    */
   public synchronized static Timer timer(String name) {
-
-    Timer timer = cache.get(name);
+    Timer timer = cache.get(key(name));
     if (timer == null) {
       System.out.println("== MetricManager: create timedMetric " + name);
       timer = new MockTimer(name, false);
-      cache.put(name, timer);
+      cache.put(key(name), timer);
     }
     return timer;
   }
 
   public synchronized static Timer tracedTimer(String name) {
-
-    Timer timer = cache.get(name);
+    Timer timer = cache.get(key(name));
     if (timer == null) {
       System.out.println("== MetricManager: create traced timedMetric " + name);
       timer = new MockTimer(name, true);
-      cache.put(name, timer);
+      cache.put(key(name), timer);
     } else {
       ((MockTimer) timer).testEnableTracing();
     }
     return timer;
   }
 
+  private synchronized static Timer timer(String name, boolean traced, String... tags) {
+    String key = key(name, tags);
+    Timer timer = cache.get(key);
+    if (timer == null) {
+      System.out.println("== MetricManager: create " + (traced ? "traced " : "") + "timedMetric " + name + ":" + Arrays.toString(tags));
+      timer = new MockTimer(name, tags, traced);
+      cache.put(key, timer);
+    } else if (traced) {
+      ((MockTimer) timer).testEnableTracing();
+    }
+    return timer;
+  }
+
+  private static String key(String name) {
+    return name;
+  }
+
+  private static String key(String name, String... tags) {
+    return name + ":" + Arrays.toString(tags);
+  }
 
   public synchronized static Timer timer(String name, int... bucketRanges) {
 
-    Timer timer = bucketCache.get(name);
+    Timer timer = bucketCache.get(key(name));
     if (timer == null) {
       System.out.println("== MetricManager: create BucketTimedMetric " + name);
       timer = new MockBucketTimer(name, false);
-      bucketCache.put(name, timer);
+      bucketCache.put(key(name), timer);
     }
     return timer;
   }
 
   public synchronized static Timer tracedTimer(String name, int... bucketRanges) {
 
-    Timer timer = bucketCache.get(name);
+    Timer timer = bucketCache.get(key(name));
     if (timer == null) {
       System.out.println("== MetricManager: create traced BucketTimedMetric " + name);
       timer = new MockBucketTimer(name, true);
-      bucketCache.put(name, timer);
+      bucketCache.put(key(name), timer);
     } else {
       ((MockBucketTimer) timer).testEnableTracing();
     }
@@ -73,27 +101,36 @@ public class Metrics {
   /**
    * For testing purpose get the TimedMetric if one has been created.
    */
-  public synchronized static MockTimer testGetTimedMetric(String name) {
-    return (MockTimer)cache.get(name);
+  public synchronized static MockTimer testGetTimedMetric(String name, String... tags) {
+    return (MockTimer) cache.get(tags.length == 0 ? key(name) : key(name, tags));
   }
 
   public synchronized static MockBucketTimer testGetBucketTimedMetric(String name) {
-    return (MockBucketTimer)bucketCache.get(name);
+    return (MockBucketTimer) bucketCache.get(key(name));
   }
 
   /**
    * Called when a timer ends so that we can assert the call occured.
    */
   protected static void testOperationEnd(String name, boolean success) {
-    testOperationEnd(name, success, "add");
+    testOperationEnd(name, new String[0], success, "add");
   }
 
   protected static void testOperationEnd(String name, boolean success, String operationKind) {
-    testOperationEnd(name, success, operationKind, null);
+    testOperationEnd(name, new String[0], success, operationKind, null);
   }
 
   protected static void testOperationEnd(String name, boolean success, String operationKind, Throwable throwable) {
+    testOperationEnd(name, new String[0], success, operationKind, throwable);
+  }
+
+  protected static void testOperationEnd(String name, String[] tags, boolean success, String operationKind) {
+    testOperationEnd(name, tags, success, operationKind, null);
+  }
+
+  protected static void testOperationEnd(String name, String[] tags, boolean success, String operationKind, Throwable throwable) {
     lastMetricName  = name;
+    lastMetricTags = Arrays.copyOf(tags, tags.length);
     lastMetricOpcode = success ? 1 : 191;
     lastOperationKind = operationKind;
     lastThrowable = throwable;
@@ -101,6 +138,10 @@ public class Metrics {
 
   public static String testLastMetricName() {
     return lastMetricName;
+  }
+
+  public static String[] testLastMetricTags() {
+    return lastMetricTags == null ? null : Arrays.copyOf(lastMetricTags, lastMetricTags.length);
   }
 
   public static boolean testLastMetricOpcodeError() {
@@ -113,9 +154,16 @@ public class Metrics {
 
   public static void testReset() {
     lastMetricName = null;
+    lastMetricTags = null;
     lastMetricOpcode = 0;
     lastOperationKind = null;
     lastThrowable = null;
+  }
+
+  public static synchronized void testClear() {
+    cache.clear();
+    bucketCache.clear();
+    testReset();
   }
 
   public static boolean testLastMetricOpcodeSuccess() {

--- a/src/test/java/io/avaje/metrics/MockTimer.java
+++ b/src/test/java/io/avaje/metrics/MockTimer.java
@@ -1,17 +1,25 @@
 package io.avaje.metrics;
 
+import java.util.Arrays;
+
 /**
  * Test Double
  */
 public class MockTimer implements Timer {
 
   private final String name;
+  private final String[] tags;
   private boolean traced;
 
   private int count;
 
   MockTimer(String name, boolean traced) {
+    this(name, new String[0], traced);
+  }
+
+  MockTimer(String name, String[] tags, boolean traced) {
     this.name = name;
+    this.tags = Arrays.copyOf(tags, tags.length);
     this.traced = traced;
   }
 
@@ -29,7 +37,7 @@ public class MockTimer implements Timer {
     long exeNanos = System.nanoTime() - startNanos;
     System.out.println("... " + name + " testOperationEnd exe:" + exeNanos + " success:" + success);
     count++;
-    Metrics.testOperationEnd(name, success, success ? "add" : "addErr");
+    Metrics.testOperationEnd(name, tags, success, success ? "add" : "addErr");
   }
 
   @Override
@@ -67,19 +75,19 @@ public class MockTimer implements Timer {
     @Override
     public void end() {
       count++;
-      Metrics.testOperationEnd(name, true, "event.end");
+      Metrics.testOperationEnd(name, tags, true, "event.end");
     }
 
     @Override
     public void endWithError() {
       count++;
-      Metrics.testOperationEnd(name, false, "event.endWithError");
+      Metrics.testOperationEnd(name, tags, false, "event.endWithError");
     }
 
     @Override
     public void endWithError(Throwable error) {
       count++;
-      Metrics.testOperationEnd(name, false, "event.endWithError", error);
+      Metrics.testOperationEnd(name, tags, false, "event.endWithError", error);
     }
   }
 }

--- a/src/test/java/io/avaje/metrics/agent/AgentManifestTest.java
+++ b/src/test/java/io/avaje/metrics/agent/AgentManifestTest.java
@@ -74,4 +74,22 @@ public class AgentManifestTest {
     assertFalse(manifest.isTimedSpansEnabled(TimedSpanMode.DEFAULT, TimedSpanMode.ON));
     assertFalse(manifest.isTimedSpansEnabled(TimedSpanMode.ON, TimedSpanMode.ON));
   }
+
+  @Test
+  public void timedMetricNaming_unsetDefaultsFullName() {
+    AgentManifest manifest = new AgentManifest();
+
+    assertFalse(manifest.isTimedMetricNamingLabelTag());
+  }
+
+  @Test
+  public void timedMetricNaming_labelTagMode() {
+    AgentManifest manifest = new AgentManifest();
+    Attributes attributes = new Attributes();
+    attributes.putValue("timedMetricNaming", "label-tag");
+
+    manifest.readToggles(attributes);
+
+    assertTrue(manifest.isTimedMetricNamingLabelTag());
+  }
 }

--- a/src/test/java/org/tagged/web/api/TaggedCustomTimedResource.java
+++ b/src/test/java/org/tagged/web/api/TaggedCustomTimedResource.java
@@ -1,0 +1,21 @@
+package org.tagged.web.api;
+
+import io.avaje.metrics.annotation.Timed;
+
+@Timed(prefix = "myapi")
+public class TaggedCustomTimedResource {
+
+  public String publicMethodNormal() {
+    return "ok";
+  }
+
+  @Timed(name = "someRandomName")
+  public String publicMethodWithName() {
+    return "ok";
+  }
+
+  @Timed(name = "myname.fully.defined")
+  public String publicMethodWithFullName() {
+    return "ok";
+  }
+}

--- a/src/test/java/org/tagged/web/api/TaggedDefaultTimedResource.java
+++ b/src/test/java/org/tagged/web/api/TaggedDefaultTimedResource.java
@@ -1,0 +1,11 @@
+package org.tagged.web.api;
+
+import io.avaje.metrics.annotation.Timed;
+
+@Timed
+public class TaggedDefaultTimedResource {
+
+  public String defaultMethod() {
+    return "ok";
+  }
+}

--- a/src/test/java/org/tagged/web/api/TaggedNamedTimedResource.java
+++ b/src/test/java/org/tagged/web/api/TaggedNamedTimedResource.java
@@ -1,0 +1,16 @@
+package org.tagged.web.api;
+
+import io.avaje.metrics.annotation.Timed;
+
+@Timed(name = "custom.base")
+public class TaggedNamedTimedResource {
+
+  public String defaultLabel() {
+    return "ok";
+  }
+
+  @Timed(name = "namedMethod")
+  public String namedLabel() {
+    return "ok";
+  }
+}

--- a/src/test/java/org/tagged/web/api/TaggedSpanTimedResource.java
+++ b/src/test/java/org/tagged/web/api/TaggedSpanTimedResource.java
@@ -1,0 +1,15 @@
+package org.tagged.web.api;
+
+import io.avaje.metrics.annotation.Timed;
+
+@Timed(prefix = "spanapi", span = Timed.SpanMode.ON)
+public class TaggedSpanTimedResource {
+
+  public String tracedMethod() {
+    return "ok";
+  }
+
+  @Timed(buckets = {100, 200})
+  public void tracedBucketMethod() {
+  }
+}

--- a/src/test/java/org/test/web/api/TaggedMetricNamingTest.java
+++ b/src/test/java/org/test/web/api/TaggedMetricNamingTest.java
@@ -1,0 +1,229 @@
+package org.test.web.api;
+
+import io.avaje.metrics.Metrics;
+import io.avaje.metrics.MockBucketTimer;
+import io.avaje.metrics.MockTimer;
+import io.avaje.metrics.agent.AgentManifest;
+import io.avaje.metrics.agent.Transformer;
+import io.avaje.metrics.agent.offline.OfflineFileTransform;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class TaggedMetricNamingTest {
+
+  @Before
+  public void before() {
+    Metrics.testClear();
+  }
+
+  @Test
+  public void plainTimer_usesBaseNameAndLabelTag() throws Exception {
+
+    invokeTransformed("org.tagged.web.api.TaggedCustomTimedResource", "publicMethodNormal", "timedMetricNaming: label-tag");
+
+    assertEquals("myapi", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:TaggedCustomTimedResource.publicMethodNormal"}, Metrics.testLastMetricTags());
+    assertTrue(Metrics.testLastOperationWasAdd());
+    MockTimer metric = Metrics.testGetTimedMetric("myapi", "label:TaggedCustomTimedResource.publicMethodNormal");
+    assertNotNull(metric);
+    assertFalse(metric.testIsTraced());
+  }
+
+  @Test
+  public void methodName_overridesLabelTag() throws Exception {
+
+    invokeTransformed("org.tagged.web.api.TaggedCustomTimedResource", "publicMethodWithName", "timedMetricNaming: label-tag");
+
+    assertEquals("myapi", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:someRandomName"}, Metrics.testLastMetricTags());
+  }
+
+  @Test
+  public void dottedMethodName_becomesLabelOverride() throws Exception {
+
+    invokeTransformed("org.tagged.web.api.TaggedCustomTimedResource", "publicMethodWithFullName", "timedMetricNaming: label-tag");
+
+    assertEquals("myapi", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:myname.fully.defined"}, Metrics.testLastMetricTags());
+  }
+
+  @Test
+  public void className_staysBaseMetricName() throws Exception {
+
+    invokeTransformed("org.tagged.web.api.TaggedNamedTimedResource", "defaultLabel", "timedMetricNaming: label-tag");
+
+    assertEquals("custom.base", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:TaggedNamedTimedResource.defaultLabel"}, Metrics.testLastMetricTags());
+
+    Metrics.testClear();
+
+    invokeTransformed("org.tagged.web.api.TaggedNamedTimedResource", "namedLabel", "timedMetricNaming: label-tag");
+
+    assertEquals("custom.base", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:namedMethod"}, Metrics.testLastMetricTags());
+  }
+
+  @Test
+  public void tracedTimer_usesEventPathAndLabelTag() throws Exception {
+
+    invokeTransformed("org.tagged.web.api.TaggedSpanTimedResource", "tracedMethod", "timedMetricNaming: label-tag");
+
+    assertEquals("spanapi", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:TaggedSpanTimedResource.tracedMethod"}, Metrics.testLastMetricTags());
+    assertTrue(Metrics.testLastOperationWasEvent());
+    MockTimer metric = Metrics.testGetTimedMetric("spanapi", "label:TaggedSpanTimedResource.tracedMethod");
+    assertNotNull(metric);
+    assertTrue(metric.testIsTraced());
+  }
+
+  @Test
+  public void nameIncludePackages_changesLabelOnly() throws Exception {
+
+    invokeTransformed("org.tagged.web.api.TaggedCustomTimedResource", "publicMethodNormal", "timedMetricNaming: label-tag", "nameIncludePackages: true");
+
+    assertEquals("myapi", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:org.tagged.web.api.TaggedCustomTimedResource.publicMethodNormal"}, Metrics.testLastMetricTags());
+  }
+
+  @Test
+  public void bucketTimer_staysFullNameInLabelTagMode() throws Exception {
+
+    invokeTransformed("org.tagged.web.api.TaggedSpanTimedResource", "tracedBucketMethod", "timedMetricNaming: label-tag");
+
+    assertEquals("spanapi.TaggedSpanTimedResource.tracedBucketMethod", Metrics.testLastMetricName());
+    assertArrayEquals(new String[0], Metrics.testLastMetricTags());
+    MockBucketTimer metric = Metrics.testGetBucketTimedMetric("spanapi.TaggedSpanTimedResource.tracedBucketMethod");
+    assertNotNull(metric);
+    assertTrue(metric.testIsTraced());
+  }
+
+  @Test
+  public void defaultNonWebBaseName_isAppComponent() throws Exception {
+
+    invokeTransformed("org.tagged.web.api.TaggedDefaultTimedResource", "defaultMethod", "timedMetricNaming: label-tag");
+
+    assertEquals("app.component", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:TaggedDefaultTimedResource.defaultMethod"}, Metrics.testLastMetricTags());
+    MockTimer metric = Metrics.testGetTimedMetric("app.component", "label:TaggedDefaultTimedResource.defaultMethod");
+    assertNotNull(metric);
+    assertFalse(metric.testIsTraced());
+  }
+
+  private void invokeTransformed(String className, String methodName, String... manifestEntries) throws Exception {
+    Path tempDir = Files.createTempDirectory("metrics-agent-tagged-");
+    try {
+      copyClassFile(className, tempDir);
+
+      AgentManifest manifest = manifest(manifestEntries);
+      Transformer transformer = new Transformer(manifest);
+      OfflineFileTransform fileTransform = new OfflineFileTransform(transformer, getClass().getClassLoader(), tempDir.toString(), tempDir.toString());
+      fileTransform.process(packageName(className));
+
+      try (TransformedClassLoader loader = new TransformedClassLoader(tempDir, getClass().getClassLoader(), className)) {
+        Class<?> type = loader.loadClass(className);
+        Metrics.testReset();
+        Method method = type.getMethod(methodName);
+        Object target = Modifier.isStatic(method.getModifiers()) ? null : type.getDeclaredConstructor().newInstance();
+        method.invoke(target);
+      }
+    } finally {
+      deleteDirectory(tempDir);
+    }
+  }
+
+  private AgentManifest manifest(String... manifestEntries) throws IOException {
+    StringBuilder builder = new StringBuilder("Manifest-Version: 1.0\n");
+    for (String manifestEntry : manifestEntries) {
+      builder.append(manifestEntry).append('\n');
+    }
+    builder.append('\n');
+
+    AgentManifest manifest = new AgentManifest();
+    try (InputStream inputStream = new ByteArrayInputStream(builder.toString().getBytes(StandardCharsets.UTF_8))) {
+      manifest.addResource(inputStream);
+    }
+    return manifest;
+  }
+
+  private void copyClassFile(String className, Path tempDir) throws IOException {
+    String resourceName = className.replace('.', '/') + ".class";
+    Path destination = tempDir.resolve(resourceName);
+    Files.createDirectories(destination.getParent());
+    try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(resourceName)) {
+      if (inputStream == null) {
+        throw new IOException("Missing class resource " + resourceName);
+      }
+      Files.copy(inputStream, destination);
+    }
+  }
+
+  private String packageName(String className) {
+    int lastDot = className.lastIndexOf('.');
+    return className.substring(0, lastDot).replace('.', '/');
+  }
+
+  private void deleteDirectory(Path dir) throws IOException {
+    try (Stream<Path> stream = Files.walk(dir)) {
+      stream.sorted(Comparator.reverseOrder()).forEach(path -> {
+        try {
+          Files.deleteIfExists(path);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      });
+    } catch (RuntimeException e) {
+      if (e.getCause() instanceof IOException) {
+        throw (IOException) e.getCause();
+      }
+      throw e;
+    }
+  }
+
+  private static final class TransformedClassLoader extends URLClassLoader {
+
+    private final String transformedClassName;
+
+    private TransformedClassLoader(Path tempDir, ClassLoader parent, String transformedClassName) throws IOException {
+      super(new URL[]{tempDir.toUri().toURL()}, parent);
+      this.transformedClassName = transformedClassName;
+    }
+
+    @Override
+    protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+      if (transformedClassName.equals(name)) {
+        Class<?> loadedClass = findLoadedClass(name);
+        if (loadedClass == null) {
+          try {
+            loadedClass = findClass(name);
+          } catch (ClassNotFoundException e) {
+            loadedClass = super.loadClass(name, false);
+          }
+        }
+        if (resolve) {
+          resolveClass(loadedClass);
+        }
+        return loadedClass;
+      }
+      return super.loadClass(name, resolve);
+    }
+  }
+}


### PR DESCRIPTION
This is better aligned to StatsD (Tags) and OpenTelemetry (Attributes) where the className + methodName part goes into tags rather than the metric name.