### PR TITLE
Behaviour Change: Default to TimedMetricNaming.LABEL_TAG (from FULLNAME)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ example `src/main/resources/metrics.mf`.
 Manifest-Version: 1.0
 packages: com.example.app.**
 timedSpans: default-off
-timedMetricNaming: label-tag
+timedMetricNaming: full-name
 spring: true
 jaxrs: true
 
@@ -77,7 +77,7 @@ parsing, so `true` enables the option and any other value is false.
 | `nameIncludePackages` | boolean, default `false` | Uses fully qualified class names in generated non-web metric names or label values. |
 | `nameTrimPackages` | package list, default empty | Legacy parsed setting. Package prefixes are stored longest-first, but current enhancement does not apply this setting to generated metric names. |
 | `timedSpans` | `default-off`, `default-child`, `disabled`; default `default-off` | Controls whether timed methods also create spans. `disabled` turns off timed spans globally, including explicit `@Timed(span = Timed.SpanMode.CHILD)` or `ROOT`. |
-| `timedMetricNaming` | `full-name`, `label-tag`; default `full-name` | Controls whether timed metric names use the full generated name or a base metric name with a generated `label:` tag. |
+| `timedMetricNaming` | `full-name`, `label-tag`; default `label-tag` | Controls whether timed metric names use the full generated name or a base metric name with a generated `label:` tag. |
 
 When `packages` is not set, the agent skips known JDK, JDBC, logging, test, and common
 library packages and checks the remaining classes. Set `packages` in production
@@ -98,12 +98,12 @@ when no recording span is current, which is useful for top-level Lambda-style ha
 
 ### Timed metric naming
 
-`timedMetricNaming` supports `full-name` and `label-tag`. If unset, `full-name` is used.
+`timedMetricNaming` supports `full-name` and `label-tag`. If unset, `label-tag` is used.
 
-- `full-name` keeps the existing metric naming, for example:
-  `web.api.CustomerResource.staticGeneral`
-- `label-tag` changes timed metrics to use the base metric name plus a `label:` tag, for example:
+- `label-tag` (default) changes timed metrics to use the base metric name plus a `label:` tag, for example:
   `Metrics.timerBuilder("web.api").tags(Tags.of("label:CustomerResource.staticGeneral")).build()`
+- `full-name` reverts to the legacy metric naming, for example:
+  `web.api.CustomerResource.staticGeneral`
 
 In `label-tag` mode:
 

--- a/src/main/java/io/avaje/metrics/agent/AgentManifest.java
+++ b/src/main/java/io/avaje/metrics/agent/AgentManifest.java
@@ -39,7 +39,7 @@ public class AgentManifest {
   private boolean includeJaxRsComponents;
   private boolean includeJEEComponents;
   private TimedSpansMode timedSpansMode = TimedSpansMode.DEFAULT_OFF;
-  private TimedMetricNaming timedMetricNaming = TimedMetricNaming.FULL_NAME;
+  private TimedMetricNaming timedMetricNaming = TimedMetricNaming.LABEL_TAG;
 
   private boolean nameIncludePackages;
   private int debugLevel;

--- a/src/main/java/io/avaje/metrics/agent/TimedMetricNaming.java
+++ b/src/main/java/io/avaje/metrics/agent/TimedMetricNaming.java
@@ -6,14 +6,14 @@ enum TimedMetricNaming {
 
   static TimedMetricNaming of(String value) {
     if (value == null || value.trim().isEmpty()) {
-      return FULL_NAME;
+      return LABEL_TAG;
     }
     switch (value.trim()) {
-      case "label-tag":
-        return LABEL_TAG;
       case "full-name":
-      default:
         return FULL_NAME;
+      case "label-tag":
+      default:
+        return LABEL_TAG;
     }
   }
 }

--- a/src/test/java/io/avaje/metrics/agent/AgentManifestTest.java
+++ b/src/test/java/io/avaje/metrics/agent/AgentManifestTest.java
@@ -99,10 +99,10 @@ public class AgentManifestTest {
   }
 
   @Test
-  public void timedMetricNaming_unsetDefaultsFullName() {
+  public void timedMetricNaming_unsetDefaultsLabelTag() {
     AgentManifest manifest = new AgentManifest();
 
-    assertFalse(manifest.isTimedMetricNamingLabelTag());
+    assertTrue(manifest.isTimedMetricNamingLabelTag());
   }
 
   @Test
@@ -114,5 +114,16 @@ public class AgentManifestTest {
     manifest.readToggles(attributes);
 
     assertTrue(manifest.isTimedMetricNamingLabelTag());
+  }
+
+  @Test
+  public void timedMetricNaming_fullNameMode() {
+    AgentManifest manifest = new AgentManifest();
+    Attributes attributes = new Attributes();
+    attributes.putValue("timedMetricNaming", "full-name");
+
+    manifest.readToggles(attributes);
+
+    assertFalse(manifest.isTimedMetricNamingLabelTag());
   }
 }

--- a/src/test/java/org/test/web/api/BucketTimerTest.java
+++ b/src/test/java/org/test/web/api/BucketTimerTest.java
@@ -5,6 +5,7 @@ import io.avaje.metrics.MockBucketTimer;
 import org.junit.Test;
 import org.test.app.OtherSimpleService;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -19,9 +20,10 @@ public class BucketTimerTest extends BaseTest {
     assertNull(Metrics.testLastMetricName());
 
     service.sayHi();
-    assertEquals("app.OtherSimpleService.sayHi", Metrics.testLastMetricName());
+    assertEquals("app.component", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:OtherSimpleService.sayHi"}, Metrics.testLastMetricTags());
 
-    MockBucketTimer metric = Metrics.testGetBucketTimedMetric("app.OtherSimpleService.saySomethingElse");
+    MockBucketTimer metric = Metrics.testGetBucketTimedMetric("app.component", "label:OtherSimpleService.saySomethingElse");
     metric.testReset();
     assertEquals(0, metric.testGetCount());
 

--- a/src/test/java/org/test/web/api/CustomTimedResourceTest.java
+++ b/src/test/java/org/test/web/api/CustomTimedResourceTest.java
@@ -5,6 +5,7 @@ package org.test.web.api;
 import io.avaje.metrics.Metrics;
 import org.junit.Test;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -24,27 +25,33 @@ public class CustomTimedResourceTest extends BaseTest {
     assertNull(Metrics.testLastMetricName());
 
     resource.publicMethodNormal();
-    assertEquals("myapi.CustomTimedResource.publicMethodNormal", Metrics.testLastMetricName());
+    assertEquals("myapi", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:CustomTimedResource.publicMethodNormal"}, Metrics.testLastMetricTags());
     assertTrue(Metrics.testLastMetricOpcodeSuccess());
 
     resource.publicMethodWithFullName();
-    assertEquals("myname.fully.defined", Metrics.testLastMetricName());
+    assertEquals("myapi", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:myname.fully.defined"}, Metrics.testLastMetricTags());
     assertTrue(Metrics.testLastMetricOpcodeSuccess());
 
     resource.publicMethodWithFullNameWhiteSpace();
-    assertEquals("myapi.CustomTimedResource.publicMethodWithFullNameWhiteSpace", Metrics.testLastMetricName());
+    assertEquals("myapi", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:CustomTimedResource.publicMethodWithFullNameWhiteSpace"}, Metrics.testLastMetricTags());
     assertTrue(Metrics.testLastMetricOpcodeSuccess());
 
     resource.publicMethodWithName();
-    assertEquals("myapi.CustomTimedResource.someRandomName", Metrics.testLastMetricName());
+    assertEquals("myapi", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:someRandomName"}, Metrics.testLastMetricTags());
     assertTrue(Metrics.testLastMetricOpcodeSuccess());
 
     resource.publicMethodWithNameWhiteSpace();
-    assertEquals("myapi.CustomTimedResource.publicMethodWithNameWhiteSpace", Metrics.testLastMetricName());
+    assertEquals("myapi", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:CustomTimedResource.publicMethodWithNameWhiteSpace"}, Metrics.testLastMetricTags());
     assertTrue(Metrics.testLastMetricOpcodeSuccess());
 
     resource.publicMethodWithMethodPrefix();
-    assertEquals("lambda.CustomTimedResource.publicMethodWithMethodPrefix", Metrics.testLastMetricName());
+    assertEquals("lambda", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:CustomTimedResource.publicMethodWithMethodPrefix"}, Metrics.testLastMetricTags());
     assertTrue(Metrics.testLastMetricOpcodeSuccess());
 
     Metrics.testReset();
@@ -68,7 +75,8 @@ public class CustomTimedResourceTest extends BaseTest {
     assertNull(Metrics.testLastMetricName());
 
     CustomTimedResource.aStaticMethodWithTimedAnnotation();
-    assertEquals("myapi.CustomTimedResource.staticGeneral", Metrics.testLastMetricName());
+    assertEquals("myapi", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:staticGeneral"}, Metrics.testLastMetricTags());
 
   }
 }

--- a/src/test/java/org/test/web/api/CustomerResourceTest.java
+++ b/src/test/java/org/test/web/api/CustomerResourceTest.java
@@ -4,6 +4,7 @@ import io.avaje.metrics.Metrics;
 import io.avaje.metrics.MockTimer;
 import org.junit.Test;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -20,9 +21,10 @@ public class CustomerResourceTest extends BaseTest {
     assertNull(Metrics.testLastMetricName());
 
     customerResource.publicMethodWithJaxrs();
-    assertEquals("web.api.CustomerResource.publicMethodWithJaxrs", Metrics.testLastMetricName());
+    assertEquals("web.api", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:CustomerResource.publicMethodWithJaxrs"}, Metrics.testLastMetricTags());
 
-    MockTimer metric = Metrics.testGetTimedMetric("web.api.CustomerResource.publicMethodWithJaxrs");
+    MockTimer metric = Metrics.testGetTimedMetric("web.api", "label:CustomerResource.publicMethodWithJaxrs");
     metric.testReset();
     assertEquals(0, metric.testGetCount());
 
@@ -56,32 +58,41 @@ public class CustomerResourceTest extends BaseTest {
     assertNull(Metrics.testLastMetricName());
 
     customerResource.publicMethodWithJaxrs();
-    assertEquals("web.api.CustomerResource.publicMethodWithJaxrs", Metrics.testLastMetricName());
+    assertEquals("web.api", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:CustomerResource.publicMethodWithJaxrs"}, Metrics.testLastMetricTags());
     assertTrue(Metrics.testLastMetricOpcodeSuccess());
 
     customerResource.nakedProtectedMethod();
-    assertEquals("web.api.CustomerResource.publicMethodWithJaxrs", Metrics.testLastMetricName());
+    assertEquals("web.api", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:CustomerResource.publicMethodWithJaxrs"}, Metrics.testLastMetricTags());
 
     customerResource.nakedPublicMethod();
-    assertEquals("web.api.CustomerResource.nakedPublicMethod", Metrics.testLastMetricName());
+    assertEquals("web.api", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:CustomerResource.nakedPublicMethod"}, Metrics.testLastMetricTags());
 
     customerResource.publicMethodWithJaxrs();
-    assertEquals("web.api.CustomerResource.publicMethodWithJaxrs", Metrics.testLastMetricName());
+    assertEquals("web.api", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:CustomerResource.publicMethodWithJaxrs"}, Metrics.testLastMetricTags());
 
     customerResource.publicMethodWithJaxrs("asd");
-    assertEquals("web.api.CustomerResource.publicMethodWithJaxrs1", Metrics.testLastMetricName());
+    assertEquals("web.api", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:CustomerResource.publicMethodWithJaxrs1"}, Metrics.testLastMetricTags());
 
     customerResource.publicMethodWithJaxrs("asd", 3);
-    assertEquals("web.api.CustomerResource.publicMethodWithJaxrs2", Metrics.testLastMetricName());
+    assertEquals("web.api", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:CustomerResource.publicMethodWithJaxrs2"}, Metrics.testLastMetricTags());
 
     customerResource.findAll("ok");
-    assertEquals("app.BaseResource.findAll", Metrics.testLastMetricName());
+    assertEquals("app.component", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:BaseResource.findAll"}, Metrics.testLastMetricTags());
 
     customerResource.delete();
-    assertEquals("app.BaseResource.delete", Metrics.testLastMetricName());
+    assertEquals("app.component", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:BaseResource.delete"}, Metrics.testLastMetricTags());
 
     customerResource.deleteX(23L, "as");// ();
-    assertEquals("app.BaseResource.deleteX", Metrics.testLastMetricName());
+    assertEquals("app.component", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:BaseResource.deleteX"}, Metrics.testLastMetricTags());
 
     Metrics.testReset();
     assertNull(Metrics.testLastMetricName());
@@ -97,7 +108,8 @@ public class CustomerResourceTest extends BaseTest {
       fail("Never get here");
 
     } catch (IllegalArgumentException expected) {
-      assertEquals("app.BaseResource.findAll", Metrics.testLastMetricName());
+      assertEquals("app.component", Metrics.testLastMetricName());
+      assertArrayEquals(new String[]{"label:BaseResource.findAll"}, Metrics.testLastMetricTags());
       assertTrue(Metrics.testLastMetricOpcodeError());
     }
   }
@@ -112,7 +124,8 @@ public class CustomerResourceTest extends BaseTest {
     assertNull(Metrics.testLastMetricName());
 
     CustomerResource.aStaticMethodWithTimedAnnotation();
-    assertEquals("web.api.CustomerResource.staticGeneral", Metrics.testLastMetricName());
+    assertEquals("web.api", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:staticGeneral"}, Metrics.testLastMetricTags());
 
   }
 }

--- a/src/test/java/org/test/web/api/DefaultSpanControllerTest.java
+++ b/src/test/java/org/test/web/api/DefaultSpanControllerTest.java
@@ -3,6 +3,7 @@ package org.test.web.api;
 import io.avaje.metrics.Metrics;
 import org.junit.Test;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -15,9 +16,10 @@ public class DefaultSpanControllerTest extends BaseTest {
 
     Metrics.testReset();
     controller.tracedEndpoint();
-    assertEquals("web.api.DefaultSpanController.tracedEndpoint", Metrics.testLastMetricName());
+    assertEquals("web.api", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:DefaultSpanController.tracedEndpoint"}, Metrics.testLastMetricTags());
     assertTrue(Metrics.testLastOperationWasEvent());
-    assertTrue(Metrics.testGetTimedMetric("web.api.DefaultSpanController.tracedEndpoint").testIsTraced());
+    assertTrue(Metrics.testGetTimedMetric("web.api", "label:DefaultSpanController.tracedEndpoint").testIsTraced());
   }
 
   @Test
@@ -26,10 +28,11 @@ public class DefaultSpanControllerTest extends BaseTest {
 
     Metrics.testReset();
     controller.rootEndpoint();
-    assertEquals("web.api.DefaultSpanController.rootEndpoint", Metrics.testLastMetricName());
+    assertEquals("web.api", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:DefaultSpanController.rootEndpoint"}, Metrics.testLastMetricTags());
     assertTrue(Metrics.testLastOperationWasEvent());
-    assertTrue(Metrics.testGetTimedMetric("web.api.DefaultSpanController.rootEndpoint").testIsTraced());
-    assertTrue(Metrics.testGetTimedMetric("web.api.DefaultSpanController.rootEndpoint").testIsRootTraced());
+    assertTrue(Metrics.testGetTimedMetric("web.api", "label:DefaultSpanController.rootEndpoint").testIsTraced());
+    assertTrue(Metrics.testGetTimedMetric("web.api", "label:DefaultSpanController.rootEndpoint").testIsRootTraced());
   }
 
   @Test
@@ -38,8 +41,9 @@ public class DefaultSpanControllerTest extends BaseTest {
 
     Metrics.testReset();
     controller.plainEndpoint();
-    assertEquals("web.api.DefaultSpanController.plainEndpoint", Metrics.testLastMetricName());
+    assertEquals("web.api", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:DefaultSpanController.plainEndpoint"}, Metrics.testLastMetricTags());
     assertTrue(Metrics.testLastOperationWasAdd());
-    assertFalse(Metrics.testGetTimedMetric("web.api.DefaultSpanController.plainEndpoint").testIsTraced());
+    assertFalse(Metrics.testGetTimedMetric("web.api", "label:DefaultSpanController.plainEndpoint").testIsTraced());
   }
 }

--- a/src/test/java/org/test/web/api/IndexResourceTest.java
+++ b/src/test/java/org/test/web/api/IndexResourceTest.java
@@ -5,6 +5,7 @@ import io.avaje.metrics.MockTimer;
 import org.junit.Test;
 import org.test.app.SimpleService;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -18,11 +19,12 @@ public class IndexResourceTest extends BaseTest {
 
     orderService.testForceError(false);
 
-    MockTimer metric = Metrics.testGetTimedMetric("app.IndexResource.get");
+    MockTimer metric = Metrics.testGetTimedMetric("app.component", "label:IndexResource.get");
     metric.testReset();
 
     orderService.get();
-    assertEquals("app.IndexResource.get", Metrics.testLastMetricName());
+    assertEquals("app.component", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:IndexResource.get"}, Metrics.testLastMetricTags());
     assertEquals(1, metric.testGetCount());
     assertTrue(Metrics.testLastMetricOpcodeSuccess());
 
@@ -36,7 +38,7 @@ public class IndexResourceTest extends BaseTest {
 
     orderService.testForceError(true);
 
-    MockTimer metric = Metrics.testGetTimedMetric("app.IndexResource.get");
+    MockTimer metric = Metrics.testGetTimedMetric("app.component", "label:IndexResource.get");
     metric.testReset();
 
     try {

--- a/src/test/java/org/test/web/api/NameMappingEnhancedTest.java
+++ b/src/test/java/org/test/web/api/NameMappingEnhancedTest.java
@@ -18,7 +18,7 @@ public class NameMappingEnhancedTest extends BaseTest {
 
     NiceService niceService = new NiceService();
 
-    MockBucketTimer metric = Metrics.testGetBucketTimedMetric("app.NiceService.doNice");
+    MockBucketTimer metric = Metrics.testGetBucketTimedMetric("app.component", "label:NiceService.doNice");
     metric.testReset();
     Metrics.testReset();
 

--- a/src/test/java/org/test/web/api/OrderServiceTest.java
+++ b/src/test/java/org/test/web/api/OrderServiceTest.java
@@ -15,7 +15,7 @@ public class OrderServiceTest extends BaseTest {
 
     OrderService orderService = new OrderService();
 
-    MockTimer metric = Metrics.testGetTimedMetric("service.OrderService.processOrders");
+    MockTimer metric = Metrics.testGetTimedMetric("service", "label:OrderService.processOrders");
     metric.testReset();
     Metrics.testReset();
 

--- a/src/test/java/org/test/web/api/SpanTimedResourceTest.java
+++ b/src/test/java/org/test/web/api/SpanTimedResourceTest.java
@@ -3,6 +3,7 @@ package org.test.web.api;
 import io.avaje.metrics.Metrics;
 import org.junit.Test;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
@@ -17,15 +18,17 @@ public class SpanTimedResourceTest extends BaseTest {
 
     Metrics.testReset();
     resource.tracedMethod();
-    assertEquals("spanapi.SpanTimedResource.tracedMethod", Metrics.testLastMetricName());
+    assertEquals("spanapi", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:SpanTimedResource.tracedMethod"}, Metrics.testLastMetricTags());
     assertTrue(Metrics.testLastOperationWasEvent());
-    assertTrue(Metrics.testGetTimedMetric("spanapi.SpanTimedResource.tracedMethod").testIsTraced());
+    assertTrue(Metrics.testGetTimedMetric("spanapi", "label:SpanTimedResource.tracedMethod").testIsTraced());
 
     Metrics.testReset();
     resource.plainMethod();
-    assertEquals("spanapi.SpanTimedResource.plainMethod", Metrics.testLastMetricName());
+    assertEquals("spanapi", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:SpanTimedResource.plainMethod"}, Metrics.testLastMetricTags());
     assertTrue(Metrics.testLastOperationWasAdd());
-    assertFalse(Metrics.testGetTimedMetric("spanapi.SpanTimedResource.plainMethod").testIsTraced());
+    assertFalse(Metrics.testGetTimedMetric("spanapi", "label:SpanTimedResource.plainMethod").testIsTraced());
   }
 
   @Test
@@ -34,10 +37,11 @@ public class SpanTimedResourceTest extends BaseTest {
 
     Metrics.testReset();
     resource.rootMethod();
-    assertEquals("spanapi.SpanTimedResource.rootMethod", Metrics.testLastMetricName());
+    assertEquals("spanapi", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:SpanTimedResource.rootMethod"}, Metrics.testLastMetricTags());
     assertTrue(Metrics.testLastOperationWasEvent());
-    assertTrue(Metrics.testGetTimedMetric("spanapi.SpanTimedResource.rootMethod").testIsTraced());
-    assertTrue(Metrics.testGetTimedMetric("spanapi.SpanTimedResource.rootMethod").testIsRootTraced());
+    assertTrue(Metrics.testGetTimedMetric("spanapi", "label:SpanTimedResource.rootMethod").testIsTraced());
+    assertTrue(Metrics.testGetTimedMetric("spanapi", "label:SpanTimedResource.rootMethod").testIsRootTraced());
   }
 
   @Test
@@ -46,9 +50,10 @@ public class SpanTimedResourceTest extends BaseTest {
 
     Metrics.testReset();
     resource.tracedBucketMethod();
-    assertEquals("spanapi.SpanTimedResource.tracedBucketMethod", Metrics.testLastMetricName());
+    assertEquals("spanapi", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:SpanTimedResource.tracedBucketMethod"}, Metrics.testLastMetricTags());
     assertTrue(Metrics.testLastOperationWasEvent());
-    assertTrue(Metrics.testGetBucketTimedMetric("spanapi.SpanTimedResource.tracedBucketMethod").testIsTraced());
+    assertTrue(Metrics.testGetBucketTimedMetric("spanapi", "label:SpanTimedResource.tracedBucketMethod").testIsTraced());
   }
 
   @Test
@@ -60,7 +65,8 @@ public class SpanTimedResourceTest extends BaseTest {
       resource.tracedError();
       fail();
     } catch (IllegalStateException expected) {
-      assertEquals("spanapi.SpanTimedResource.tracedError", Metrics.testLastMetricName());
+      assertEquals("spanapi", Metrics.testLastMetricName());
+      assertArrayEquals(new String[]{"label:SpanTimedResource.tracedError"}, Metrics.testLastMetricTags());
       assertTrue(Metrics.testLastMetricOpcodeError());
       assertEquals("event.endWithError", Metrics.testLastOperationKind());
       assertSame(expected, Metrics.testLastThrowable());

--- a/src/test/java/org/test/web/api/SpringServiceAndRepositoryCallingTest.java
+++ b/src/test/java/org/test/web/api/SpringServiceAndRepositoryCallingTest.java
@@ -8,6 +8,7 @@ import org.test.app.service.ContactDataLayer;
 import org.test.app.service.ContactRepository;
 import org.test.app.service.ContactServiceImpl;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -21,15 +22,16 @@ public class SpringServiceAndRepositoryCallingTest extends BaseTest {
     ContactDataLayer contactDataLayer = new ContactRepository();
     ContactServiceImpl impl = new ContactServiceImpl(contactDataLayer);
 
-    MockTimer alertMetric = Metrics.testGetTimedMetric("service.ContactServiceImpl.sendAlert");
+    MockTimer alertMetric = Metrics.testGetTimedMetric("service", "label:ContactServiceImpl.sendAlert");
     alertMetric.testReset();
 
-    MockTimer repoMetric = Metrics.testGetTimedMetric("repo.ContactRepository.fetchData");
+    MockTimer repoMetric = Metrics.testGetTimedMetric("repo", "label:ContactRepository.fetchData");
     repoMetric.testReset();
 
 
     impl.sendAlert(new Contact());
-    assertEquals("service.ContactServiceImpl.sendAlert", Metrics.testLastMetricName());
+    assertEquals("service", Metrics.testLastMetricName());
+    assertArrayEquals(new String[]{"label:ContactServiceImpl.sendAlert"}, Metrics.testLastMetricTags());
     assertEquals(1, alertMetric.testGetCount());
     assertEquals(1, repoMetric.testGetCount());
 

--- a/src/test/java/org/test/web/api/TaggedMetricNamingTest.java
+++ b/src/test/java/org/test/web/api/TaggedMetricNamingTest.java
@@ -140,7 +140,7 @@ public class TaggedMetricNamingTest {
   @Test
   public void timedTags_classTagsApplyInFullNameMode() throws Exception {
 
-    invokeTransformed("org.tagged.web.api.TaggedTimedTagsResource", "classTagged");
+    invokeTransformed("org.tagged.web.api.TaggedTimedTagsResource", "classTagged", "timedMetricNaming: full-name");
 
     assertEquals("tagapi.TaggedTimedTagsResource.classTagged", Metrics.testLastMetricName());
     assertArrayEquals(new String[]{"type:class", "component:billing"}, Metrics.testLastMetricTags());
@@ -152,7 +152,7 @@ public class TaggedMetricNamingTest {
   @Test
   public void timedTags_methodTagsAppendToClassTagsInFullNameMode() throws Exception {
 
-    invokeTransformed("org.tagged.web.api.TaggedTimedTagsResource", "methodTagged");
+    invokeTransformed("org.tagged.web.api.TaggedTimedTagsResource", "methodTagged", "timedMetricNaming: full-name");
 
     assertEquals("tagapi.TaggedTimedTagsResource.methodTagged", Metrics.testLastMetricName());
     assertArrayEquals(new String[]{"type:class", "component:billing", "operation:sync", "source:method"}, Metrics.testLastMetricTags());
@@ -169,7 +169,7 @@ public class TaggedMetricNamingTest {
   @Test
   public void timedTags_bucketTimersIncludeCustomTags() throws Exception {
 
-    invokeTransformed("org.tagged.web.api.TaggedTimedTagsResource", "bucketTagged");
+    invokeTransformed("org.tagged.web.api.TaggedTimedTagsResource", "bucketTagged", "timedMetricNaming: full-name");
 
     assertEquals("tagapi.TaggedTimedTagsResource.bucketTagged", Metrics.testLastMetricName());
     assertArrayEquals(new String[]{"type:class", "component:billing", "operation:bucket"}, Metrics.testLastMetricTags());
@@ -185,7 +185,7 @@ public class TaggedMetricNamingTest {
   @Test
   public void timedTags_tracedTimersIncludeCustomTags() throws Exception {
 
-    invokeTransformed("org.tagged.web.api.TaggedTimedTagsResource", "tracedTagged");
+    invokeTransformed("org.tagged.web.api.TaggedTimedTagsResource", "tracedTagged", "timedMetricNaming: full-name");
 
     assertEquals("tagapi.TaggedTimedTagsResource.tracedTagged", Metrics.testLastMetricName());
     assertArrayEquals(new String[]{"type:class", "component:billing", "operation:trace"}, Metrics.testLastMetricTags());


### PR DESCRIPTION
So FULLNAME was good and natural for the old CollectD world and now we are more in the StatsD labels and tags world. This change will come with a major version bump and comes such that "newer apps" get the natural default going forward.